### PR TITLE
Decode body to make signature string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
   - "pypy"
 # command to install dependencies
 install: "python setup.py install"

--- a/requests_mauth/__init__.py
+++ b/requests_mauth/__init__.py
@@ -2,5 +2,5 @@
 __author__ = 'isparks'
 
 from .client import MAuth
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 

--- a/requests_mauth/client.py
+++ b/requests_mauth/client.py
@@ -61,6 +61,9 @@ class MAuth(requests.auth.AuthBase):
         if seconds_since_epoch is None:
             seconds_since_epoch = int(time.time())
 
+        if isinstance(body, bytes):
+            body = body.decode('utf-8')
+
         vals = dict(verb=verb,
                     url_path=url_path,
                     body=body or '',

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -6,6 +6,7 @@ from requests_mauth.client import MAuth
 import time
 from requests import Request
 import os
+import json
 
 
 class RequestMock(object):
@@ -43,6 +44,19 @@ class TestStringToSign(MAuthBaseTest):
 
         # Test we got the epoch we put in, back again
         self.assertEqual(tested[1],epoch)
+
+    def test_string_to_sign_binary_body(self):
+        expected = "GET" + "\n" \
+            + "/studies/123/users" + "\n" \
+            +'{"key": "data"}\n' \
+            + self.app_id \
+            + "\n" \
+            +  "1309891855"
+
+        epoch = 1309891855
+        mr = RequestMock("GET","/studies/123/users",json.dumps( { 'key': 'data' } ).encode('utf8'))
+        tested = self.client.make_signature_string(mr.method, mr.url, mr.body, seconds_since_epoch=epoch)
+        self.assertEqual(tested[0], expected)
 
     def test_string_to_sign_no_epoch(self):
         """Test that epoch is supplied for us if we don't"""


### PR DESCRIPTION
Body must be a bytes-like object:
https://github.com/requests/requests/blob/v2.18.4/requests/models.py#L455-L460

Without decoding it, `b` will be added when making a signature string in Python 3:
```python
body = 'a'.encode('utf-8')
u'{body}'.format(body=body)
#=> "b'a'"
```

The signature string won't match with the one generated in server side so will get `401 unauthorized`

@vipinj @glow-mdsol @mdsol/team-10 