### PR TITLE
Remove setting (overriding) Content-Type header in requests-mauth

### DIFF
--- a/requests_mauth/__init__.py
+++ b/requests_mauth/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 __author__ = 'isparks'
 
-__version__ = '1.0.3'
+__version__ = '1.1.0'
 
 from .client import MAuth

--- a/requests_mauth/client.py
+++ b/requests_mauth/client.py
@@ -57,8 +57,7 @@ class MAuth(requests.auth.AuthBase):
         :param int seconds_since_epoch: The number of seconds since the Epoch
         """
         return {'X-MWS-Authentication': 'MWS %s:%s' % (self.app_uuid, signed_string,),
-                'X-MWS-Time': str(seconds_since_epoch),
-                'Content-Type': 'application/json;charset=utf-8',
+                'X-MWS-Time': str(seconds_since_epoch)
                 }
 
     def make_signature_string(self, verb, url_path, body, seconds_since_epoch=None):


### PR DESCRIPTION
### Background

requests-mauth is always adding `'Content-Type': 'application/json;charset=utf-8'` to all requests, regardless of method and content.


### Change summary

Remove setting the `Content-Type` header in requests-mauth to delegate adding the Content-Type header to the [requests](https://requests.readthedocs.io/en/latest/user/quickstart/#make-a-request) library.

If needed, please add the `Content-Type` header manually:
```python
import json

url = 'https://api.github.com/some/endpoint'
payload = {'some': 'data'}

r = requests.post(url, data=json.dumps(payload), headers={'Content-Type': 'application/json'})
```

or use the json parameter:
> Using the `json` parameter in the request will change the Content-Type in the header to `application/json`.
```python
r = requests.post(url, json=payload)
```

@glow-mdsol @jcarres-mdsol