### PR TITLE
Update travis to move fast_finish under jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 dist: xenial
 language: python
-matrix:
-  fast_finish: true
+
 jobs:
+  fast_finish: true
   include:
     - python: "2.7"
     - python: "3.4"


### PR DESCRIPTION
Somehow Travis CI started to not run on multiple Python versions with the existing Travis file:
https://travis-ci.org/github/mdsol/requests-mauth/builds/660776998?utm_medium=notification&utm_source=github_status

Moving `fast_finish: true` under `jobs` fixes the issue:
https://travis-ci.org/github/mdsol/requests-mauth/builds/661243225?utm_source=github_status&utm_medium=notification

@glow-mdsol @jcarres-mdsol 